### PR TITLE
Improve DecimalField

### DIFF
--- a/DecimalField.swift
+++ b/DecimalField.swift
@@ -74,14 +74,22 @@ struct DecimalField : View {
         }, onCommit: {
             self.onCommit()
         })
-            .onAppear(){ // Otherwise textfield is empty when view appears
-                self.hasInitialTextValue = true
-                // Any `textValue` from this point on is considered valid and
-                // should be synced with `value`.
-                if let value = self.value {
-                    // Synchronize `textValue` with `value`; can't be done earlier
-                    self.textValue = self.formatter.string(from: NSDecimalNumber(decimal: value)) ?? ""
+            .onReceive(Just(textValue)) {
+                guard self.hasInitialTextValue else {
+                    // We don't have a usable `textValue` yet -- bail out.
+                    return
                 }
+                // This is the only place we update `value`.
+                self.value = self.formatter.number(from: $0)?.decimalValue
+        }
+        .onAppear(){ // Otherwise textfield is empty when view appears
+            self.hasInitialTextValue = true
+            // Any `textValue` from this point on is considered valid and
+            // should be synced with `value`.
+            if let value = self.value {
+                // Synchronize `textValue` with `value`; can't be done earlier
+                self.textValue = self.formatter.string(from: NSDecimalNumber(decimal: value)) ?? ""
+            }
         }
         .keyboardType(.decimalPad)
     }

--- a/DecimalField.swift
+++ b/DecimalField.swift
@@ -26,114 +26,125 @@
 //
 
 import SwiftUI
+import Combine
 
 struct DecimalField : View {
-    let label: String
+    let label: LocalizedStringKey
     @Binding var value: Decimal?
     let formatter: NumberFormatter
-    @State var displayedText: String? = nil
-    @State var lastFormattedValue: Decimal? = nil
-    
+    let onEditingChanged: (Bool) -> Void
+    let onCommit: () -> Void
+
+    // The text shown by the wrapped TextField. This is also the "source of
+    // truth" for the `value`.
+    @State private var textValue: String = ""
+
+    // When the view loads, `textValue` is not synced with `value`.
+    // This flag ensures we don't try to get a `value` out of `textValue`
+    // before the view is fully initialized.
+    @State private var hasInitialTextValue = false
+
+    init(
+        _ label: LocalizedStringKey,
+        value: Binding<Decimal?>,
+        formatter: NumberFormatter,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onCommit: @escaping () -> Void = {}
+    ) {
+        self.label = label
+        _value = value
+        self.formatter = formatter
+        self.onEditingChanged = onEditingChanged
+        self.onCommit = onCommit
+    }
+
     var body: some View {
-        let b = Binding<String>(
-            get: { return self.displayedText ?? "" },
-            set: { newValue in
-                self.displayedText = newValue
-                self.value = self.formatter.number(from: newValue)?.decimalValue
-        })
-        
-        return TextField(label, text: b, onEditingChanged: { inFocus in
-            if !inFocus {
-                self.lastFormattedValue = self.formatter.number(from: b.wrappedValue)?.decimalValue
-                if self.lastFormattedValue != nil {
-                    DispatchQueue.main.async {
-                        b.wrappedValue = self.formatter.string(for: self.lastFormattedValue!) ?? ""
-                    }
-                }
+        TextField(label, text: $textValue, onEditingChanged: { isInFocus in
+            // When the field is in focus we replace the field's contents
+            // with a plain unformatted number. When not in focus, the field
+            // is treated as a label and shows the formatted value.
+            if isInFocus {
+                self.textValue = self.value?.description ?? ""
+            } else {
+                let f = self.formatter
+                let newValue = f.number(from: self.textValue)?.decimalValue
+                self.textValue = f.string(for: newValue) ?? ""
             }
+            self.onEditingChanged(isInFocus)
+        }, onCommit: {
+            self.onCommit()
         })
             .onAppear(){ // Otherwise textfield is empty when view appears
-                 print(self.value?.description ?? "no value")
-                 if let value = self.value, let valueString =  self.formatter.string(from: NSDecimalNumber(decimal: value)) {
-                     b.wrappedValue = valueString
-                 }
-            }
-            .padding()
-            .keyboardType(.decimalPad)
+                self.hasInitialTextValue = true
+                // Any `textValue` from this point on is considered valid and
+                // should be synced with `value`.
+                if let value = self.value {
+                    // Synchronize `textValue` with `value`; can't be done earlier
+                    self.textValue = self.formatter.string(from: NSDecimalNumber(decimal: value)) ?? ""
+                }
+        }
+        .keyboardType(.decimalPad)
     }
 }
 
 struct DecimalField_Previews: PreviewProvider {
-    
     static var previews: some View {
         TipCalculator()
     }
-    
+
     struct TipCalculator: View {
-        @State var dollarValue: Decimal?
+        @State var amount: Decimal? = 50
         @State var tipRate: Decimal?
-        
-        var tipValue: Decimal? {
-            guard let dollarValue = self.dollarValue, let tipRate = self.tipRate else { return nil }
-            return dollarValue * tipRate
+
+        var tipValue: Decimal {
+            guard let amount = self.amount, let tipRate = self.tipRate else {
+                return 0
+            }
+            return amount * tipRate / 100
         }
-        
-        var totalValue: Decimal? {
-            guard let dollarValue = self.dollarValue, let tipValue = self.tipValue else { return nil }
-            return dollarValue + tipValue
+
+        var totalValue: Decimal {
+            guard let amount = self.amount else {
+                return tipValue
+            }
+            return amount + tipValue
         }
-        
+
         static var currencyFormatter: NumberFormatter {
             let nf = NumberFormatter()
             nf.numberStyle = .currency
             nf.isLenient = true
             return nf
         }
-        
+
         static var percentFormatter: NumberFormatter {
             let nf = NumberFormatter()
             nf.numberStyle = .percent
+            // preserve input as-is, otherwise 10 becomes 0.1, which makes
+            // sense but is less intuitive for input
+            nf.multiplier = 1
             nf.isLenient = true
             return nf
         }
-        
+
         var body: some View {
-            ScrollView {
-                VStack(alignment: .leading) {
-                    VStack {
-                        HStack {
-                            Text("Check Amount")
-                            Divider()
-                            DecimalField(label: "Amount", value: $dollarValue, formatter: Self.currencyFormatter)
-                        }
-                        
-                        HStack {
-                            Text("Tip Rate")
-                            Divider()
-                            DecimalField(label: "Rate", value: $tipRate, formatter: Self.percentFormatter)
-                        }
-                    }
-                    .padding()
-                    
-                    VStack {
-                        HStack {
-                            Text("Tip Amount")
-                            Divider()
-                            Text(Self.currencyFormatter.string(for: tipValue) ?? "-")
-                            Spacer()
-                        }
-                        HStack {
-                            Text("Total")
-                            Divider()
-                            Text(Self.currencyFormatter.string(for: totalValue) ?? "-")
-                            Spacer()
-                        }
-                    }
-                    .padding()
-                    Spacer()
+            Form {
+                Section {
+                    DecimalField("Amount", value: $amount, formatter: Self.currencyFormatter)
+                    DecimalField("Tip Rate", value: $tipRate, formatter: Self.percentFormatter)
                 }
-                .fixedSize(horizontal: false, vertical: true)
-                .padding()
+                Section {
+                    HStack {
+                        Text("Tip Amount")
+                        Spacer()
+                        Text(Self.currencyFormatter.string(for: tipValue)!)
+                    }
+                    HStack {
+                        Text("Total")
+                        Spacer()
+                        Text(Self.currencyFormatter.string(for: totalValue)!)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes a major issue with the old implementation, in that it would not pick up the changed value if the user hit a "Done" button while the field was in focus and presented in a sheet (I didn't check if the bug exists in an "inline" form).

The key is the `.onReceive` modifier that receives a stream of values as the user types  into the field and lets us process those values.

It also changes the behaviour somewhat, which might be a deal-breaker for you or some people: the field now shows the formatted value (ie. `$10.00`) like before, but as soon as the user focuses input on the field it changes back to a plain value (ie. `10`) to ease editing. On blur, it obviously shows the formatted value again.