### PR TITLE
[IMP] The edit string is localized

### DIFF
--- a/DecimalField.swift
+++ b/DecimalField.swift
@@ -34,16 +34,19 @@ struct DecimalField : View {
     let formatter: NumberFormatter
     let onEditingChanged: (Bool) -> Void
     let onCommit: () -> Void
-
+    
+    // The formatter that formats the editing string.
+    private let editStringFormatter: NumberFormatter
+    
     // The text shown by the wrapped TextField. This is also the "source of
     // truth" for the `value`.
     @State private var textValue: String = ""
-
+    
     // When the view loads, `textValue` is not synced with `value`.
     // This flag ensures we don't try to get a `value` out of `textValue`
     // before the view is fully initialized.
     @State private var hasInitialTextValue = false
-
+    
     init(
         _ label: LocalizedStringKey,
         value: Binding<Decimal?>,
@@ -52,19 +55,32 @@ struct DecimalField : View {
         onCommit: @escaping () -> Void = {}
     ) {
         self.label = label
-        _value = value
+        self._value = value
         self.formatter = formatter
         self.onEditingChanged = onEditingChanged
         self.onCommit = onCommit
+        
+        // We configure the edit string formatter to behave like the
+        // input formatter without add the currency symbol,
+        // percent symbol, etc...
+        self.editStringFormatter = NumberFormatter()
+        self.editStringFormatter.allowsFloats = formatter.allowsFloats
+        self.editStringFormatter.alwaysShowsDecimalSeparator = formatter.alwaysShowsDecimalSeparator
+        self.editStringFormatter.decimalSeparator = formatter.decimalSeparator
+        self.editStringFormatter.maximumIntegerDigits = formatter.maximumIntegerDigits
+        self.editStringFormatter.maximumSignificantDigits = formatter.maximumSignificantDigits
+        self.editStringFormatter.maximumFractionDigits = formatter.maximumFractionDigits
+        self.editStringFormatter.multiplier = formatter.multiplier
     }
-
+    
     var body: some View {
         TextField(label, text: $textValue, onEditingChanged: { isInFocus in
             // When the field is in focus we replace the field's contents
-            // with a plain unformatted number. When not in focus, the field
+            // with a plain specifically formatted number. When not in focus, the field
             // is treated as a label and shows the formatted value.
             if isInFocus {
-                self.textValue = self.value?.description ?? ""
+                let newValue = self.formatter.number(from: self.textValue)
+                self.textValue = self.editStringFormatter.string(for: newValue) ?? ""
             } else {
                 let f = self.formatter
                 let newValue = f.number(from: self.textValue)?.decimalValue
@@ -82,14 +98,14 @@ struct DecimalField : View {
                 // This is the only place we update `value`.
                 self.value = self.formatter.number(from: $0)?.decimalValue
         }
-        .onAppear(){ // Otherwise textfield is empty when view appears
-            self.hasInitialTextValue = true
-            // Any `textValue` from this point on is considered valid and
-            // should be synced with `value`.
-            if let value = self.value {
-                // Synchronize `textValue` with `value`; can't be done earlier
-                self.textValue = self.formatter.string(from: NSDecimalNumber(decimal: value)) ?? ""
-            }
+            .onAppear(){ // Otherwise textfield is empty when view appears
+                self.hasInitialTextValue = true
+                // Any `textValue` from this point on is considered valid and
+                // should be synced with `value`.
+                if let value = self.value {
+                    // Synchronize `textValue` with `value`; can't be done earlier
+                    self.textValue = self.formatter.string(from: NSDecimalNumber(decimal: value)) ?? ""
+                }
         }
         .keyboardType(.decimalPad)
     }
@@ -99,42 +115,39 @@ struct DecimalField_Previews: PreviewProvider {
     static var previews: some View {
         TipCalculator()
     }
-
+    
     struct TipCalculator: View {
         @State var amount: Decimal? = 50
         @State var tipRate: Decimal?
-
+        
         var tipValue: Decimal {
             guard let amount = self.amount, let tipRate = self.tipRate else {
                 return 0
             }
-            return amount * tipRate / 100
+            return amount * tipRate
         }
-
+        
         var totalValue: Decimal {
             guard let amount = self.amount else {
                 return tipValue
             }
             return amount + tipValue
         }
-
+        
         static var currencyFormatter: NumberFormatter {
             let nf = NumberFormatter()
             nf.numberStyle = .currency
             nf.isLenient = true
             return nf
         }
-
+        
         static var percentFormatter: NumberFormatter {
             let nf = NumberFormatter()
             nf.numberStyle = .percent
-            // preserve input as-is, otherwise 10 becomes 0.1, which makes
-            // sense but is less intuitive for input
-            nf.multiplier = 1
             nf.isLenient = true
             return nf
         }
-
+        
         var body: some View {
             Form {
                 Section {


### PR DESCRIPTION
[IMP] The use of another formatter to format the edit string allows to use a percent formatter without tweaking its `multiplier` property.