### PR TITLE
Convert to Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "DecimalField",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(name: "DecimalField", targets: ["DecimalField"])
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(name: "DecimalField", dependencies: [])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ this writing, the native support for `numberFormatter`s in
 
 Various folks[1] have suggested that the way around this is to create
 a `Binding<String>` that manages conversion between string and numeric
-values. This is indeed possible -- and is part of what this code
+values. This is indeed possible – and is part of what this code
 does. But there is currently an additional problem with `TextField`,
 and IIRC, it's also a maddening problem with `UITextField` in UIKit:
 Input validation (and the associated conversion of string to numeric
@@ -46,6 +46,6 @@ per-keystroke basis but you do not want to use that conversion to
 update the text field string contents until after the user is no
 longer typing in the field.
 
-Please enjoy. Pull requests et c. welcome.
+Please enjoy. Pull requests etc. welcome.
 
 [1]: See [this Stack Overflow post](https://stackoverflow.com/questions/56799456/swiftui-textfield-with-formatter-not-working) and [this Twitter thread](https://twitter.com/olebegemann/status/1146823791605112833?lang=en).

--- a/Sources/DecimalField/DecimalField.swift
+++ b/Sources/DecimalField/DecimalField.swift
@@ -28,12 +28,12 @@
 import SwiftUI
 import Combine
 
-struct DecimalField : View {
-    let label: LocalizedStringKey
-    @Binding var value: Decimal?
-    let formatter: NumberFormatter
-    let onEditingChanged: (Bool) -> Void
-    let onCommit: () -> Void
+public struct DecimalField: View {
+    public let label: LocalizedStringKey
+    @Binding public var value: Decimal?
+    public let formatter: NumberFormatter
+    public let onEditingChanged: (Bool) -> Void
+    public let onCommit: () -> Void
 
     // The text shown by the wrapped TextField. This is also the "source of
     // truth" for the `value`.
@@ -44,7 +44,7 @@ struct DecimalField : View {
     // before the view is fully initialized.
     @State private var hasInitialTextValue = false
 
-    init(
+    public init(
         _ label: LocalizedStringKey,
         value: Binding<Decimal?>,
         formatter: NumberFormatter,
@@ -58,7 +58,7 @@ struct DecimalField : View {
         self.onCommit = onCommit
     }
 
-    var body: some View {
+    public var body: some View {
         TextField(label, text: $textValue, onEditingChanged: { isInFocus in
             // When the field is in focus we replace the field's contents
             // with a plain unformatted number. When not in focus, the field
@@ -74,15 +74,16 @@ struct DecimalField : View {
         }, onCommit: {
             self.onCommit()
         })
-            .onReceive(Just(textValue)) {
-                guard self.hasInitialTextValue else {
-                    // We don't have a usable `textValue` yet -- bail out.
-                    return
-                }
-                // This is the only place we update `value`.
-                self.value = self.formatter.number(from: $0)?.decimalValue
+        .onReceive(Just(textValue)) {
+            guard self.hasInitialTextValue else {
+                // We don't have a usable `textValue` yet -- bail out.
+                return
+            }
+            // This is the only place we update `value`.
+            self.value = self.formatter.number(from: $0)?.decimalValue
         }
-        .onAppear(){ // Otherwise textfield is empty when view appears
+        .onAppear() {
+            // Otherwise textfield is empty when view appears
             self.hasInitialTextValue = true
             // Any `textValue` from this point on is considered valid and
             // should be synced with `value`.


### PR DESCRIPTION
Thanks for creating this – just what I was looking for when facing some issues with numerical `TextField`s in SwiftUI lately!

Changes:
* Converted to a Swift Package by adding a `Package.swift` file that defines the module as `DecimalField`, moving the source into the right folder structure, and making sure the `public` access modifier is used
* Fixed a minor typo in `README.md`

— Seb